### PR TITLE
Update `degit` command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This will create a copy of this repo in a Github repository of your choice but y
 ### Hard mode
 
 #### With `npx` (requires node)
-    $ npx degit https://github.com/18F/federalist-uswds-gatsby <destination-folder>
+    $ npx degit https://github.com/18F/federalist-uswds-gatsby#main <destination-folder>
     $ cd <destination-folder>
 
 #### Push to your Github repository


### PR DESCRIPTION
Change proposed:
* Add the default branch name (`main`) to the degit command

Fixes error:
```
➜  projects npx degit https://github.com/18F/federalist-uswds-gatsby sara-gatsby-uswds
! could not find commit hash for master
```

After change:
```
➜  projects npx degit https://github.com/18F/federalist-uswds-gatsby#main sara-gatsby-uswds
> cloned 18F/federalist-uswds-gatsby#main to sara-gatsby-uswds
```


Closes #196