### PR TITLE
Search.gov Suggested Updates

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -30,7 +30,7 @@ const loadScript = (src, onLoad, attrs = {}) => new Promise(resolve => {
 });
 
 export const onInitialClientRender = () => {
-  const { dap, ga } = siteMetadata;
+  const { dap, ga , searchgov } = siteMetadata;
   const { pathname } = window.location;
 
   const scripts = [];
@@ -62,6 +62,21 @@ export const onInitialClientRender = () => {
       gtag('config', '${ga.ua}', { 'anonymize_ip': true, 'forceSSL': true });
     `;
     document.body.appendChild(gtag);
+  }
+
+
+
+  if (searchgov && searchgov.affiliate && searchgov.suggestions) {
+    const config = document.createElement('script');
+    config.text = `
+      var usasearch_config = { siteHandle: "${searchgov.affiliate}" };
+    `;
+    document.body.appendChild(config);
+    
+    const src="https://search.usa.gov/javascripts/remote.loader.js";
+    const onLoad = () => console.log("Typeahead suggestions loaded.");
+    scripts.push(loadScript(src, onLoad));
+    
   }
 
   Promise.all(scripts)

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
-    // Replace the Site URL with your domain, ex. https://agency.gov 
-    siteUrl: 'https://agency.gov',
+    // Replace the Site URL with your domain, ex. https://example.gov 
+    siteUrl: 'https://example.gov',
     author: 'Foo',
     title: `Agency Name`,
     description: `Agency Name (EAC) Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,7 @@
 module.exports = {
   siteMetadata: {
+    // Replace the Site URL with your domain, ex. https://agency.gov 
+    siteUrl: 'https://agency.gov',
     author: 'Foo',
     title: `Agency Name`,
     description: `Agency Name (EAC) Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -42,17 +44,21 @@ module.exports = {
      */
     searchgov: {
       
-      // You should not change this.
+      // Only change this if you're using a CNAME. Learn more here: https://search.gov/manual/cname.html
       endpoint: 'https://search.usa.gov',
       
-      // replace this with your search.gov account
-      affiliate: 'federalist-uswds-example',
+      // Replace this with your search.gov account.
+      affiliate: 'usasearch',
       
-      // replace with your access key
-      access_key: 'xX1gtb2RcnLbIYkHAcB6IaTRr4ZfN-p16ofcyUebeko=',
+      // Replace this with your access key.
+      access_key: 'Q_XTNBtjvH-l0g1JU5QVj9G6vJRFnYkoR2NMSZKFWBc=',
       
-      // this renders the results within the page instead of sending to user to search.gov
+      // This renders the results within the page instead of sending to user to search.gov.
       inline: true, 
+
+      // This allows Search.gov to present relevant type-ahead search suggestions in your website's search box. 
+      // If you do not want to present search suggestions, set this value to false.
+      suggestions: true,
     },
 
     /**
@@ -139,6 +145,21 @@ module.exports = {
       },
     },
     `gatsby-plugin-netlify-cms`,
+    `gatsby-plugin-sitemap`,
+    {
+      resolve: 'gatsby-plugin-robots-txt',
+      options: {
+        resolveEnv: () => process.env.GATSBY_ENV,
+        env: {
+          development: {
+            policy: [{ userAgent: '*', disallow: ['/'] }]
+          },
+          production: {
+            policy: [{ userAgent: '*', allow: '/' }]
+          }
+        }
+      }
+    }
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,11 +47,11 @@ module.exports = {
       // Only change this if you're using a CNAME. Learn more here: https://search.gov/manual/cname.html
       endpoint: 'https://search.usa.gov',
       
-      // Replace this with your search.gov account.
-      affiliate: 'usasearch',
+      // Replace this with your search.gov site handle.
+      affiliate: 'federalist-uswds-example',
       
       // Replace this with your access key.
-      access_key: 'Q_XTNBtjvH-l0g1JU5QVj9G6vJRFnYkoR2NMSZKFWBc=',
+      access_key: 'xX1gtb2RcnLbIYkHAcB6IaTRr4ZfN-p16ofcyUebeko=',
       
       // This renders the results within the page instead of sending to user to search.gov.
       inline: true, 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "gatsby-plugin-netlify-cms": "^4.7.0",
     "gatsby-plugin-offline": "^3.7.1",
     "gatsby-plugin-react-helmet": "^3.7.0",
+    "gatsby-plugin-robots-txt": "^1.6.14",
     "gatsby-plugin-sass": "^2.8.0",
+    "gatsby-plugin-sitemap": "^5.2.0",
     "gatsby-source-filesystem": "^2.8.1",
     "gatsby-transformer-remark": "^2.13.1",
     "netlify-cms-app": "^2.14.8",
@@ -30,7 +32,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0",
-    "uswds": "^2.10.0"
+    "uswds": "^2.12.2"
   },
   "devDependencies": {
     "eslint-config-react-app": "^5.2.1",

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -25,7 +25,7 @@ function SEO({ description, lang, meta, title }) {
     `
   );
 
-  const metaDescription = description || site.siteMetadata.description;
+  const metaDescription = description;
 
   return (
     <Helmet

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -44,13 +44,19 @@ const SearchPage = ({ data, location }) => {
                       className="padding-bottom-5 margin-top-4 usa-prose border-bottom-05 border-base-lightest"
                     >
                       <b className="title">
-                        <a href={r.url}>{r.title}</a>
+                        <a href={r.url} 
+                          dangerouslySetInnerHTML={{
+                            __html: r.title
+                              .replace(/\uE000/g, '<span class="bg-yellow">')
+                              .replace(/\uE001/g, '</span>'),
+                          }}
+                        >
+                        </a>
                       </b>
                       <div
                         dangerouslySetInnerHTML={{
                           __html: r.snippet
-                            .replace(/class=/g, 'className=')
-                            .replace(/\uE000/g, '<span className="bg-yellow">')
+                            .replace(/\uE000/g, '<span class="bg-yellow">')
                             .replace(/\uE001/g, '</span>'),
                         }}
                       />

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -4,13 +4,13 @@ import { graphql } from 'gatsby';
 import Layout from '../components/layout';
 
 const SearchPage = ({ data, location }) => {
-  const { access_key, affiliate, endpoint } = data.site.siteMetadata.searchgov;
+  const { access_key, affiliate } = data.site.siteMetadata.searchgov;
   const query = new URLSearchParams(location.search).get('query');
 
   const [results, setResults] = useState([]);
 
   useEffect(() => {
-    const searchEndpoint = new URL(`${endpoint}/api/v2/search/i14y`);
+    const searchEndpoint = new URL(`https://api.gsa.gov/technology/searchgov/v2/results/i14y`);
     searchEndpoint.searchParams.append('affiliate', affiliate);
     searchEndpoint.searchParams.append('access_key', access_key);
     searchEndpoint.searchParams.append('query', query);
@@ -26,7 +26,7 @@ const SearchPage = ({ data, location }) => {
         setResults(posts.web.results);
       })
       .catch(err => console.log(err));
-  }, [query, access_key, affiliate, endpoint]);
+  }, [query, access_key, affiliate]);
 
   return (
     <Layout>


### PR DESCRIPTION
Hi team,

We made a few suggested changes that were incorporated into the Jekyll template (https://github.com/18F/federalist-uswds-jekyll/pull/205), so we wanted to ensure they were also present in the Gatsby template for ease of use. I'm much less familiar with Gatsby/React, so please feel free to change the implementation as you see fit. We're hoping that with these changes, sites will be better set up for Search.gov indexing and display of search results.

**Summary of Changes**
- Updated USWDS version for compatibility: this was required to get the site to run
- Updated Search.gov instructional comments: these now mirror the Jekyll template
- Added typeahead functionality to search bar: I added this mirroring the implementation for DAP and GA, but please do change if it's not ideal.
- Removed site description as the meta description fallback: Repetitive meta descriptions can cause false matches in search, and in general do not help from an SEO perspective. 
- Fixed text highlighting in title & snippet for search results: Updated so that the matched query terms appear with a yellow highlight, as they do in the Jekyll template.
- Added sitemap plugin (needs work): I added the plugin to generate a sitemap (gatsby-plugin-sitemap), but I wasn't able to figure out how to add last modified dates successfully. Search.gov uses the <lastmod> date as a trigger to index updated content, so it is important to include. 
- Added robots.txt: I added the plugin gatsby-plugin-robots-txt, which adds a robots.txt file at the root of the site. Because the sitemap is in a non-standard position, it should be listed in the robots.txt for easy finding. I also added a rule to disallow crawling for development environments, but allow on production. 

Please reach out with any questions - also happy to meet if that's easier! 
