### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloud-gov/pages-ops


### PR DESCRIPTION
Closes out https://github.com/cloud-gov/product/issues/3342

## Changes proposed in this pull request:

- Add pages ops as codeowner

## Security considerations

Owning will sum
